### PR TITLE
Preserve host as entered (i.e. do not strip trailing slash if present)

### DIFF
--- a/source/couchpotatoAlfred.py
+++ b/source/couchpotatoAlfred.py
@@ -54,8 +54,8 @@ def get_data(method_name=""):
     req.add_header("Accept", "application/json")
     try:
         res = urllib2.urlopen(req)
-    except urllib2.URLError as err:
-        print "Can't connect to CouchPotato ({})".format(err)
+    except urllib2.URLError:
+        print "Can't connect to CouchPotato"
         raise SystemExit()
 
     return json.loads(res.read())


### PR DESCRIPTION
Preserve hostname as entered, add trailing slash internally where necessary.

If CouchPotato is running behind another webserver, the trailing slash may be required, and stripping it will cause opening CP in the web browser to fail.
